### PR TITLE
Add MySQL 5.7 support.

### DIFF
--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -81,7 +81,7 @@ module BigintPk
       c.execute %Q{
         ALTER TABLE #{c.quote_table_name table_name}
         MODIFY COLUMN #{c.quote_column_name key_name}
-        bigint(20) DEFAULT NULL #{'auto_increment' if is_primary_key}
+        bigint(20) #{is_primary_key ? 'auto_increment' : 'DEFAULT NULL'}
       }.gsub(/\s+/, ' ').strip
     when 'SQLite'
       # noop; sqlite always has 64bit pkeys

--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -40,7 +40,7 @@ module BigintPk
 
     if ca.const_defined? :AbstractMysqlAdapter
       ca::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:primary_key] = 
-        'bigint(20) DEFAULT NULL auto_increment PRIMARY KEY'
+        'bigint(20) auto_increment PRIMARY KEY'
     end
   end
 


### PR DESCRIPTION
Mysql2::Error: All parts of a PRIMARY KEY must be NOT NULL.
